### PR TITLE
Expo issue with underscore in app slugs

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         <action android:name="android.intent.action.VIEW"/>
         <category android:name="android.intent.category.DEFAULT"/>
         <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:scheme="hello-expo-scheme"/>
         <data android:scheme="dk.homburg.expo.HelloExpo"/>
         <data android:scheme="exp+helloexpo"/>
       </intent-filter>

--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "HelloExpo",
     "slug": "hello_expo",
+    "scheme": "hello-expo-scheme",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",


### PR DESCRIPTION
App slug with underscore results in registered android app scheme without underscore: https://github.com/homburg/HelloExpo/blob/a3821c755cba4688cbfc5f788a2532e1286dc819/android/app/src/main/AndroidManifest.xml#L29C26-L29C26